### PR TITLE
Making the ` torchlive-cli init` command independent of locally installed Python version

### DIFF
--- a/react-native-template-pytorch-live/script.js
+++ b/react-native-template-pytorch-live/script.js
@@ -9,17 +9,29 @@
  */
 
 const execSync = require('child_process').execSync;
+const process = require('process');
+
+const makeModels = () => {
+  execSync('source ./venv/bin/activate && \
+              python3 -m pip install --upgrade pip && \
+              python3 -m pip install -r requirements.txt --no-cache-dir && \
+              python3 -W ignore make_models.py');
+}
+
+process.chdir('./models');
 
 switch (process.platform) {
   case 'darwin':
+    execSync('brew install python@3.9');
+    execSync('/usr/local/opt/python@3.9/bin/python3 -m venv ./venv');
+    makeModels();
+    break;
   case 'linux':
-    execSync(
-      'cd ./models && python3 -m venv ./venv 2> ./error.log \
-            && source ./venv/bin/activate 2> ./error.log \
-            && pip install --upgrade pip 2> ./error.log \
-            && pip install -r requirements.txt 2> ./error.log \
-            && python -W ignore make_models.py 2> ./error.log',
-    );
+    execSync('pip install virtualenv');
+    // TODO: Test with Linux
+    execSync('sudo apt-get install python3.9')
+    execSync('virtualenv --python=/usr/bin/python3.9 venv');
+    makeModels();
     break;
   case 'win32':
     // TODO: Implement

--- a/react-native-template-pytorch-live/template/models/requirements.txt
+++ b/react-native-template-pytorch-live/template/models/requirements.txt
@@ -1,5 +1,5 @@
 torch==1.10.0
 torchvision==0.11.1
 torchaudio==0.10.0
-transformers==4.6.1
-scipy==1.7.1
+transformers==4.11.3
+scipy==1.7.3


### PR DESCRIPTION
## Summary

TorchVision v0.11.1 needs the version 21.3.1 from PIP. Previously to this PR, the version of PIP depended on the version of Python that was installed locally:

<img width="454" alt="Screenshot 2021-12-07 at 04 01 21" src="https://user-images.githubusercontent.com/39239895/144958395-00c44d03-e300-4e27-a4fe-965c5352ea8e.png">

See that it uses Python3, which was installed by the user. If the Python version installed locally cannot upgrade PIP to the version 21.3.1, then dependencies like TorchVision won't be installed and the command `npx torchlive-cli init MyProject` will result in an error (in the following case, Python3 has the version 3.7.12):

![064129A3-E6CD-4C2A-AC6C-3D08D2C78311_1_105_c](https://user-images.githubusercontent.com/39239895/144958605-470c7789-e2c3-4572-aa88-ea882f154ce5.jpeg)

I am pretty sure this will make the installation process much easier as the user will avoid having problems related to the Python version and will not have to worry about doing any extra step (installing an specific version of Python, creating an alias for Python3 to point to the recently installed Python, ...).

The use of the flag `--no-cache-dir` is due to ARM. I had some .whl files downloaded locally that were not available for ARM. However, at the time of installing any dependency, PIP used that wheel and I run into some errors. Maybe there will be people using Apple Silicon in my position, so I find it useful to keep it in order to make the Python installation completely independent of the existing local files.

This solution also implements a function called makeModules used just to modulate the code. This function will be shared both by MacOS and Linux. However, we use a different package manager to install Python, so they cannot be joined.

The linux implementation was not checked since PyTorchLive is initially only focused on MacOS.

In conclusion, with this approach it no longer matters which version of Python is installed locally.

## Changelog

[TEMPLATE] [TEMPLATE CREATION] - Making the `torchlive-cli init` command independent of locally installed Python version

## Test Plan

First of all, if you're using an ARM CPU, you have to replace the `make_models.js` file with the one in the following pull request: [RuntimeError related to quantization solved for ARM architecture](https://github.com/pytorch/live/pull/8). If you're using a x86 CPU it's not necessary that you perform this step.

In both cases, we're going to use the same command (feel free to change the name of the project and replace the path `/Users/aaron/Documents/github/` by your absolute path to the current working directory where you are using the command):
```bash
$ npx react-native init LiveM1Test --template file://Users/aaron/Documents/github/live/react-native-template-pytorch-live/
```

---
### Before

In this case, `python3 -V` outputs the version 3.7.12. This is the result of running the command specified before:

![064129A3-E6CD-4C2A-AC6C-3D08D2C78311_1_105_c](https://user-images.githubusercontent.com/39239895/144960302-b20f90fc-3e8c-4c66-a891-70bc1585d122.jpeg)

---
### After

In this case, `python3 -V` still outputs the version 3.7.12. However, the `script.js` file uses its own version on the virtual environment. This is the result of running the command specified before:

![C0ECFF91-E416-46E6-8306-BE474457A8AF](https://user-images.githubusercontent.com/39239895/144961103-be5329fa-7037-4f63-be24-43346c8c1a7b.jpeg)

