### PR TITLE
correct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   Build your AI powered mobile prototypes in minutes:
   <a href="https://playtorch.dev/docs/tutorials/get-started">Get Started</a>
   <span> · </span>
-  <a href="https://playtorch.dev/docs/tutorials/image-classification">Tutorials</a>
+  <a href="https://playtorch.dev/docs/tutorials/snacks/image-classification/">Tutorials</a>
   <span> · </span>
   <a href="https://playtorch.dev/docs/api/cli">API</a>
 </h3>


### PR DESCRIPTION
## Summary
Tutorial link in README.md is not work.

![image](https://user-images.githubusercontent.com/80466735/180633283-32d4b352-92b3-4b18-87fc-e59d6172a28e.png)

Tutorial link in README.md is 'https://playtorch.dev/docs/tutorials/image-classification'.  But it is linked as Page Not Found. 

![image](https://user-images.githubusercontent.com/80466735/180633327-e3f21e4e-f434-44a2-b872-69e5f4b1b4ae.png)

You should probably set the path to 'https://playtorch.dev/docs/tutorials/snacks/image-classification/' 
 It's minor, but I think it'd be nice to fix it :)

## Changelog

[Tutorial] [Tutorial Link] - Fixed tutorial link in README.md file.
![image](https://user-images.githubusercontent.com/80466735/180634902-67c2cf6e-69c8-4ef0-8aeb-bde6c7c4f24d.png)

CLA Check