### PR TITLE
Remove deploy-website badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <p>&nbsp;</p>
 
-[![Deploy Website](https://github.com/facebookresearch/playtorch/actions/workflows/deploy-website.yml/badge.svg)](https://github.com/facebookresearch/playtorch/actions/workflows/deploy-website.yml) [![Torchlive CLI](https://github.com/facebookresearch/playtorch/actions/workflows/build-cli.yml/badge.svg)](https://github.com/facebookresearch/playtorch/actions/workflows/build-cli.yml) [![Build Android Template App](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-android.yml/badge.svg)](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-android.yml) [![Build iOS Template App](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-ios.yml/badge.svg)](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-ios.yml)
+[![Torchlive CLI](https://github.com/facebookresearch/playtorch/actions/workflows/build-cli.yml/badge.svg)](https://github.com/facebookresearch/playtorch/actions/workflows/build-cli.yml) [![Build Android Template App](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-android.yml/badge.svg)](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-android.yml) [![Build iOS Template App](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-ios.yml/badge.svg)](https://github.com/facebookresearch/playtorch/actions/workflows/build-template-ios.yml)
 
 <p>
   <a href="https://www.npmjs.org/package/react-native-pytorch-core">


### PR DESCRIPTION
## Summary

The website deployment changed from gh-pages to Vercel. The deploy-website GH action no longer exists, so removing it from the README.md

## Changelog

Removed deploy website badge from README.md

## Test Plan

![image](https://user-images.githubusercontent.com/489051/181808093-ab26c5c8-d738-45af-8111-34eb8a4823a3.png)

