### PR TITLE
Hide google play store button on homepage when on ios devices

### DIFF
--- a/website/src/components/MobileBrowserDetector.js
+++ b/website/src/components/MobileBrowserDetector.js
@@ -7,6 +7,8 @@
  * @format
  */
 
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
 /**
  * NOTE: This is not a totally reliable method. There essentially aren't any
  * totally reliable methods. So be careful using this.
@@ -15,9 +17,16 @@
  */
 
 /**
- * @returns boolean if we suspect the user is using an android mobile device
+ * @returns boolean if we suspect the user is using an android mobile device, or false if in SSR
  */
 export function getIsLikelyAndroidDevice() {
+  // Return false for SSR environment
+  if (!ExecutionEnvironment.canUseDOM) {
+    return false;
+  }
+  if (navigator == null) {
+    return false;
+  }
   if (/Android/i.test(navigator.userAgent)) {
     return true;
   }
@@ -25,9 +34,16 @@ export function getIsLikelyAndroidDevice() {
 }
 
 /**
- * @returns boolean if we suspect the user is using an ios mobile device
+ * @returns boolean if we suspect the user is using an ios mobile device, or false if in SSR
  */
 export function getIsLikelyIOSDevice() {
+  // Return false for SSR environment
+  if (!ExecutionEnvironment.canUseDOM) {
+    return false;
+  }
+  if (navigator == null) {
+    return false;
+  }
   if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) {
     return true;
   }
@@ -35,7 +51,7 @@ export function getIsLikelyIOSDevice() {
 }
 
 /**
- * @returns boolean if we suspect the user is using an android/ios mobile device
+ * @returns boolean if we suspect the user is using an android/ios mobile device, or false if in SSR
  */
 export function getIsLikelyAndroidOrIOSDevice() {
   return getIsLikelyAndroidDevice() || getIsLikelyIOSDevice();

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -7,12 +7,13 @@
  * @format
  */
 
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useMemo} from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import styles from './index.module.css';
 import DocVideo from '../components/DocVideo';
 import ExternalLinks from '@site/src/constants/ExternalLinks';
+import {getIsLikelyIOSDevice} from '@site/src/components/MobileBrowserDetector';
 
 import AppStoreBadge from '@site/static/img/download_on_the_app_store_badge.svg';
 import GooglePlayBadgeUrl from '@site/static/img/google_play_badge.png';
@@ -59,6 +60,8 @@ function AppStoreRow({
   appStoreLink,
   googlePlayLink,
 }) {
+  const isLikelyIOSDevice = useMemo(() => getIsLikelyIOSDevice(), []);
+
   return (
     <div
       className={clsx([
@@ -72,21 +75,27 @@ function AppStoreRow({
           {content}
         </div>
         <div className={clsx([styles.appStoreButtonRow])}>
-          <a
-            className={clsx([styles.googlePlayButtonWrapper])}
-            href={googlePlayLink || '#'}>
-            <img
-              className={clsx([styles.googlePlayBadge])}
-              alt="Google Play Badge"
-              src={GooglePlayBadgeUrl}
-            />
-          </a>
+          {
+            // Hide the google play store button on iOS devices to satisfy the iOS app store approvers when the
+            // home page is reached via the PlayTorch app
+            isLikelyIOSDevice ? null : (
+              <a
+                className={clsx([styles.googlePlayButtonWrapper])}
+                href={googlePlayLink || '#'}>
+                <img
+                  className={clsx([styles.googlePlayBadge])}
+                  alt="Google Play Badge"
+                  src={GooglePlayBadgeUrl}
+                />
+              </a>
+            )
+          }
           <a
             className={clsx([
               styles.appStoreButtonWrapper,
               styles.buttonWrapper,
             ])}
-            href={appStoreLink || '#'}>
+            href={appStoreLink}>
             <div className={styles.button}>JOIN THE iOS BETA</div>
             {false && (
               <AppStoreBadge


### PR DESCRIPTION
Summary: iOS app store requires this when the link is reached from inside the PlayTorch app

Differential Revision: D38366219

