### PR TITLE
Use universal App Store link

### DIFF
--- a/website/src/constants/ExternalLinks.js
+++ b/website/src/constants/ExternalLinks.js
@@ -8,7 +8,7 @@
  */
 
 const ExternalLinks = {
-  APP_STORE: 'https://apps.apple.com/us/app/playtorch/id1632121045',
+  APP_STORE: 'https://apps.apple.com/app/playtorch/id1632121045',
   DISCORD: 'https://discord.gg/sQkXTqEt33',
   GITHUB: 'https://github.com/facebookresearch/playtorch',
   GOOGLE_PLAY_STORE:


### PR DESCRIPTION
Summary: The App Store link included the `/us` url path component, which will land users on the U.S. App Store. Instead, this change removes the `/us` path to land users in their respective country's App Store

Reviewed By: liuyinglao

Differential Revision: D38413440

