### PR TITLE
correct License file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Read our [**Contributing Guide**][contribute] to learn about our development pro
 ## License
 PlayTorch is MIT licensed, as found in the [LICENSE][license] file.
 
-[license]: LICENSE.md
+[license]: LICENSE


### PR DESCRIPTION
## Summary
License file link in README.md is not crrect file.

![image](https://user-images.githubusercontent.com/80466735/185794859-62a7431c-9f4e-4b98-8876-33f399db2802.png)

License file link is 'https://github.com/cjfghk5697/playtorch/blob/main/LICENSE.md'. But  it is linked as 404 error page. Because the License file name is not 'LICENSE.md'.

![image](https://user-images.githubusercontent.com/80466735/185794954-b06cf38e-bec8-42eb-804c-a22974b00255.png)

So I change file name from 'LICENSE.md' to 'LICENSE'. 

It worked well ' https://github.com/facebookresearch/playtorch/blob/main/LICENSE' 😊

## Changelog

![image](https://user-images.githubusercontent.com/80466735/185795149-cd1deec8-9221-4f92-8990-54881ba8a9c9.png)

[LICENSE] [LICENSE File Name] - Fixed License link


