### PR TITLE
Match any exception type for Tensor indexing API

### DIFF
--- a/react-native-pytorch-core/cxx/src/torchlive/torch/TensorHostObject.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/TensorHostObject.cpp
@@ -705,7 +705,7 @@ jsi::Value TensorHostObject::get(
   int idx = -1;
   try {
     idx = std::stoi(name.c_str());
-  } catch (const std::exception& e) {
+  } catch (...) {
     // Cannot parse name value to int. This can happen when the name in bracket
     // or dot notion is not an int (e.g., tensor['foo']).
     // Let's ignore this exception here since this function will return


### PR DESCRIPTION
Summary:
The tensor indexing API relies on exceptions when a prop name cannot be converted to an int via `std::stoi`.

After upgrading to Expo 46, it causes a runtime error (`std::exception&`), which doesn't get caught with the current `catch`. The change broadens the `catch` to match any exception (`catch (...)`), which fixes the issue.

The reasons are not clear, but it's assumed to be a compiler flag change. We continue to investigate, but in the meantime, this change unblock anyone who is facing the same issue

Reviewed By: justinhaaheim

Differential Revision: D39148492

