### PR TITLE
Added method to load local model file to Image Classification tutorial

### DIFF
--- a/website/docs/tutorials/prepare-custom-model.mdx
+++ b/website/docs/tutorials/prepare-custom-model.mdx
@@ -54,7 +54,7 @@ Create the `export_model.py` file, add the Python script above, and then run Pyt
 python3 export_model.py
 ```
 
-The script will create a file `mobilenet_v3_small.ptl`. Upload the `mobilenet_v3_small.ptl` file to a server that's publicly accessible, and then head over to the [image classification tutorial](./snacks/image-classification.mdx) to see how you can use it with PlayTorch.
+The script will create a file `mobilenet_v3_small.ptl`. Upload the `mobilenet_v3_small.ptl` file to a server that's publicly accessible, and then head over to the [image classification tutorial](./snacks/image-classification.mdx) to see how you can use it with PlayTorch. Alternatively, you may also have the `mobilenet_v3_small.ptl` file placed in the appropriate directory in your project.
 
 ## Give us feedback
 

--- a/website/docs/tutorials/snacks/image-classification.mdx
+++ b/website/docs/tutorials/snacks/image-classification.mdx
@@ -421,6 +421,8 @@ export default async function classifyImage(image) {
 
 Since we are initializing the model the first time we run the `classifyImage` function, it will be slower. Subsequent runs will go much faster since they don't have to download the model or load it into memory.
 
+If you do not wish to upload your model to a publicly accessible server, you may instead place the file in a directory of your choice and replace the line `const filePath = await MobileModel.download(MODEL_URL);` with `const filePath = await MobileModel.download(require('./path/to/model.ptl'));`.
+
 :::
 
 Now that we are actually running the model, let's try it out in the PlayTorch app again and see what it logs. You should see a class label in the logs which is a word or list of words.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Following the tutorial for [Prepare Custom Model](https://playtorch.dev/docs/tutorials/prepare-custom-model/) and [Image Classification](https://playtorch.dev/docs/tutorials/snacks/image-classification/), I thought I had to upload my model files to a publicly accessible server in order to use them with PlayTorch. It was not working for me due to some device storage issues in my target device, but I found the following [issue](https://github.com/facebookresearch/playtorch/issues/88) which helped me load the model from a file saved in the app directory. I thought that this information should be more readily available in the tutorial and hence added a few lines describing how to do that.

## Changelog

Just added some lines to the website tutorial, namely Prepare Custom Model and Image Classification.

[CATEGORY] [TYPE] - Message

## Test Plan

Only documentation is changed so no code test is needed.
