### PR TITLE
Prevent OOM for MNIST examples

### DIFF
--- a/react-native-pytorch-core/example/src/toolbox/models/MNIST.tsx
+++ b/react-native-pytorch-core/example/src/toolbox/models/MNIST.tsx
@@ -287,6 +287,11 @@ export default function MNIST() {
       animationHandleRef.current = requestAnimationFrame(() => {
         const trail = trailRef.current;
         if (trail != null) {
+          // The canvas context requires clearing after the change in
+          // https://github.com/facebookresearch/playtorch/commit/78221e8da9b3229bce63204629633eb602bba86c
+          // Without ctx.clear(), the app will run out of memory and crash.
+          ctx.clear();
+
           // fill background by drawing a rect
           ctx.fillStyle = COLOR_CANVAS_BACKGROUND;
           ctx.fillRect(0, 0, canvasSize, canvasSize);

--- a/react-native-pytorch-core/src/CanvasView.tsx
+++ b/react-native-pytorch-core/src/CanvasView.tsx
@@ -228,8 +228,6 @@ export interface CanvasRenderingContext2D {
 
   /**
    * Clears the entire canvas to be transparent.
-   *
-   * @deprecated This function will be removed in the beta release.
    */
   clear(): void;
 

--- a/react-native-template-pytorch-live/template/src/examples/MNISTExample.tsx
+++ b/react-native-template-pytorch-live/template/src/examples/MNISTExample.tsx
@@ -296,6 +296,11 @@ export default function MNISTExample() {
       animator.start(() => {
         const trail = trailRef.current;
         if (trail != null) {
+          // The canvas context requires clearing after the change in
+          // https://github.com/facebookresearch/playtorch/commit/78221e8da9b3229bce63204629633eb602bba86c
+          // Without ctx.clear(), the app will run out of memory and crash.
+          ctx.clear();
+
           // Here we use `layout` to get the canvas size
           const size = [layout?.width || 0, layout?.height || 0];
 


### PR DESCRIPTION
Summary:
The MNIST example in the PlayTorch app crashes after drawing several numbers on the canvas. The canvas context2d needs to be cleared after drawing.

The change clears the context2d before drawing on the canvas to avoid OOM.

Also removing the `deprecated` directive from `clear` while it is needed to certain canvas use cases

Reviewed By: liuyinglao

Differential Revision: D39418643

