### PR TITLE
Ignore install-jsi.ts

### DIFF
--- a/react-native-pytorch-core/src/install-jsi.ts
+++ b/react-native-pytorch-core/src/install-jsi.ts
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @internal
+ * @ignore
+ * @packageDocumentation
  */
 
 // Adapted from react-native-quick-sqlite


### PR DESCRIPTION
Summary:
Mark `install-jsi.ts` as `internal` to hide it from the TypeDoc. This file is only used internal to `react-native-pytorch-core`

https://typedoc.org/tags/internal/

Reviewed By: chrisklaiber

Differential Revision: D39661426

