### PR TITLE
Introduce new image toBlob API function signature

### DIFF
--- a/react-native-pytorch-core/android/src/main/cpp/torchlive/media/NativeJSRefBridge.cpp
+++ b/react-native-pytorch-core/android/src/main/cpp/torchlive/media/NativeJSRefBridge.cpp
@@ -80,6 +80,27 @@ std::unique_ptr<torchlive::media::Blob> toBlob(const std::string& refId) {
       std::move(data), size, type->toStdString());
 }
 
+std::unique_ptr<torchlive::media::Blob> toBlob(std::shared_ptr<IImage> image) {
+  std::shared_ptr<Image> derivedImage = std::dynamic_pointer_cast<Image>(image);
+
+  auto mediaUtilsClass = getMediaUtilsClass();
+  auto imageToByteBufferMethod =
+      mediaUtilsClass
+          ->getStaticMethod<local_ref<JByteBuffer>(alias_ref<JIImage>)>(
+              "imageToByteBuffer");
+
+  local_ref<JByteBuffer> buffer =
+      imageToByteBufferMethod(mediaUtilsClass, derivedImage->image_);
+
+  uint8_t* const bytes = buffer->getDirectBytes();
+  size_t const size = buffer->getDirectSize();
+  auto data = std::make_unique<uint8_t[]>(size);
+  std::memcpy(data.get(), bytes, size);
+  std::string blobType = Blob::kBlobTypeImageRGB;
+  return std::make_unique<torchlive::media::Blob>(
+      std::move(data), size, blobType);
+}
+
 } // namespace media
 
 namespace experimental {

--- a/react-native-pytorch-core/android/src/main/cpp/torchlive/media/image/Image.h
+++ b/react-native-pytorch-core/android/src/main/cpp/torchlive/media/image/Image.h
@@ -37,8 +37,9 @@ class Image : public IImage {
 
   void close() const override;
 
- private:
   facebook::jni::global_ref<JIImage> image_;
+
+ private:
   std::string id_;
 };
 

--- a/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/media/MediaUtils.java
+++ b/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/media/MediaUtils.java
@@ -61,6 +61,13 @@ public class MediaUtils {
 
   @DoNotStrip
   @Keep
+  public static ByteBuffer imageToByteBuffer(final IImage image) {
+    final Bitmap bitmap = image.getBitmap();
+    return bitmapToByteBuffer(bitmap);
+  }
+
+  @DoNotStrip
+  @Keep
   public static Bitmap blobToBitmap(
       final ByteBuffer buffer,
       final int width,
@@ -97,6 +104,35 @@ public class MediaUtils {
     }
     bitmap.setPixels(pixels, 0, width, 0, 0, width, height);
     return bitmap;
+  }
+
+  @DoNotStrip
+  @Keep
+  public static ByteBuffer bitmapToByteBuffer(Bitmap bitmap) {
+    byte[] buffer = bitmapToRGB(bitmap);
+    ByteBuffer byteBuffer = ByteBuffer.allocateDirect(buffer.length);
+    byteBuffer.order(ByteOrder.nativeOrder());
+    byteBuffer.put(buffer);
+    return byteBuffer;
+  }
+
+  @DoNotStrip
+  @Keep
+  public static byte[] bitmapToRGB(final Bitmap bitmap) {
+    final int[] pixels = new int[bitmap.getWidth() * bitmap.getHeight()];
+    final byte[] bytes = new byte[pixels.length * 3];
+    bitmap.getPixels(pixels, 0, bitmap.getWidth(), 0, 0, bitmap.getWidth(), bitmap.getHeight());
+    int i = 0;
+    for (int pixel : pixels) {
+      // Get components assuming is ARGB
+      int R = (pixel >> 16) & 0xff;
+      int G = (pixel >> 8) & 0xff;
+      int B = pixel & 0xff;
+      bytes[i++] = (byte) R;
+      bytes[i++] = (byte) G;
+      bytes[i++] = (byte) B;
+    }
+    return bytes;
   }
 
   @DoNotStrip

--- a/react-native-pytorch-core/cxx/src/torchlive/experimental/ExperimentalNamespace.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/experimental/ExperimentalNamespace.cpp
@@ -20,7 +20,7 @@ using namespace utils::helpers;
 
 namespace audio {
 
-Value audioFromBytesImpl(
+static Value audioFromBytesImpl(
     Runtime& runtime,
     const Value& thisValue,
     const Value* arguments,
@@ -61,7 +61,7 @@ Value audioFromBytesImpl(
   return promiseValue;
 }
 
-Value audioRemoveWAVHeaderImpl(
+static Value audioRemoveWAVHeaderImpl(
     Runtime& runtime,
     const Value& thisValue,
     const Value* arguments,

--- a/react-native-pytorch-core/cxx/src/torchlive/media/Blob.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/Blob.cpp
@@ -16,7 +16,7 @@ Blob::Blob(
     const std::string& type)
     : buffer_(std::move(buffer)), byteLength_(byteLength), type_(type) {}
 
-uint8_t* const Blob::getDirectBytes() const {
+uint8_t* Blob::getDirectBytes() const {
   return buffer_.get();
 }
 

--- a/react-native-pytorch-core/cxx/src/torchlive/media/Blob.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/Blob.h
@@ -29,7 +29,7 @@ class Blob {
       size_t byteLength,
       const std::string& type = "");
 
-  uint8_t* const getDirectBytes() const;
+  uint8_t* getDirectBytes() const;
   size_t getDirectSize() const noexcept;
   const std::string& getType() const noexcept;
 

--- a/react-native-pytorch-core/cxx/src/torchlive/media/BlobHostObject.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/BlobHostObject.cpp
@@ -28,7 +28,7 @@ jsi::Value BlobObjectWithNoData(jsi::Runtime& runtime) {
 
 } // namespace
 
-jsi::Value arrayBufferImpl(
+static jsi::Value arrayBufferImpl(
     jsi::Runtime& runtime,
     const jsi::Value& thisValue,
     const jsi::Value* arguments,
@@ -56,7 +56,7 @@ jsi::Value arrayBufferImpl(
   return promiseValue;
 }
 
-jsi::Value sliceImpl(
+static jsi::Value sliceImpl(
     jsi::Runtime& runtime,
     const jsi::Value& thisValue,
     const jsi::Value* arguments,

--- a/react-native-pytorch-core/cxx/src/torchlive/media/MediaNamespace.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/MediaNamespace.cpp
@@ -128,6 +128,11 @@ jsi::Value toBlobImpl(
     const auto& tensor =
         obj.asHostObject<torchlive::torch::TensorHostObject>(runtime)->tensor;
     blob = tensorToBlob(tensor);
+  } else if (obj.isHostObject<torchlive::media::ImageHostObject>(runtime)) {
+    const auto& image =
+        obj.asHostObject<torchlive::media::ImageHostObject>(runtime)
+            ->getImage();
+    blob = torchlive::media::toBlob(image);
   } else {
     const auto ID_PROP = jsi::PropNameID::forUtf8(runtime, std::string("ID"));
     if (!obj.hasProperty(runtime, ID_PROP)) {

--- a/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridge.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridge.h
@@ -23,6 +23,8 @@ imageFromBlob(const Blob& blob, double width, double height);
 
 std::unique_ptr<torchlive::media::Blob> toBlob(const std::string& refId);
 
+std::unique_ptr<torchlive::media::Blob> toBlob(std::shared_ptr<IImage> image);
+
 } // namespace media
 
 namespace experimental {

--- a/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
@@ -6,7 +6,7 @@
  */
 
 #ifdef __ANDROID__
-#elif defined(TARGET_OS_IPHONE)
+#elif __APPLE__
 #else
 
 #include "NativeJSRefBridge.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
@@ -26,6 +26,12 @@ std::unique_ptr<torchlive::media::Blob> toBlob(const std::string& refId) {
   return std::make_unique<torchlive::media::Blob>(std::move(data), size);
 }
 
+std::unique_ptr<torchlive::media::Blob> toBlob(std::shared_ptr<IImage> image) {
+  size_t const size = 0;
+  auto data = std::unique_ptr<uint8_t[]>(0);
+  return std::make_unique<torchlive::media::Blob>(std::move(data), size);
+}
+
 } // namespace media
 
 namespace experimental {

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/DictHostObject.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/DictHostObject.h
@@ -9,7 +9,11 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 namespace torchlive {
 namespace torch {

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/IValueHostObject.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/IValueHostObject.h
@@ -9,7 +9,12 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/script.h>
+#pragma clang diagnostic pop
+
 #include "../common/BaseHostObject.h"
 
 namespace torchlive {

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/TensorHostObject.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/TensorHostObject.cpp
@@ -743,9 +743,8 @@ jsi::Function TensorHostObject::createToString(jsi::Runtime& runtime) {
                           const jsi::Value& thisValue,
                           const jsi::Value* arguments,
                           size_t count) -> jsi::Value {
-    auto tensor = this->tensor;
     std::ostringstream stream;
-    stream << tensor;
+    stream << this->tensor;
     std::string tensor_string = stream.str();
     auto val = jsi::String::createFromUtf8(runtime, tensor_string);
     return jsi::Value(std::move(val));
@@ -760,8 +759,7 @@ jsi::Function TensorHostObject::createSize(jsi::Runtime& runtime) {
                       const jsi::Value& thisValue,
                       const jsi::Value* arguments,
                       size_t count) -> jsi::Value {
-    auto tensor = this->tensor;
-    torch_::IntArrayRef dims = tensor.sizes();
+    torch_::IntArrayRef dims = this->tensor.sizes();
     jsi::Array jsShape = jsi::Array(runtime, dims.size());
     for (int i = 0; i < dims.size(); i++) {
       jsShape.setValueAtIndex(runtime, i, jsi::Value((int)dims[i]));

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/TensorHostObject.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/TensorHostObject.h
@@ -9,8 +9,13 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <ATen/NativeFunctions.h>
 #include <torch/script.h>
+#pragma clang diagnostic pop
+
 #include <string>
 #include <vector>
 

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/TorchNamespace.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/TorchNamespace.cpp
@@ -174,7 +174,6 @@ jsi::Value fromBlobImpl(
   auto tensorOptions =
       utils::helpers::parseTensorOptions(runtime, arguments, 2, count);
   auto blob = blobHostObject->blob.get();
-  auto size = blob->getDirectSize();
   uint8_t* const buffer = blob->getDirectBytes();
   if (!tensorOptions.has_dtype()) {
     // explicitly set to default uint8 dtype

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/jit/JITNamespace.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/jit/JITNamespace.cpp
@@ -7,9 +7,13 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 #include "../../common/AsyncTask.h"
 #include "../../torch/utils/ArgumentParser.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/jit/mobile/ModuleHostObject.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/jit/mobile/ModuleHostObject.cpp
@@ -39,7 +39,6 @@ std::string getSyncMethodPrefix(const std::string& propName) {
 
   return propName.substr(0, prefixLength);
 }
-} // namespace
 
 MethodAsyncTask createMethodAsyncTask(
     torch_::jit::mobile::Module& m,
@@ -92,6 +91,7 @@ MethodAsyncTask createMethodAsyncTask(
         return utils::converter::ivalueToJSIValue(runtime, value);
       });
 }
+} // namespace
 
 ModuleHostObject::ModuleHostObject(
     jsi::Runtime& rt,

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/jit/mobile/ModuleHostObject.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/jit/mobile/ModuleHostObject.cpp
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/module.h>
+#pragma clang diagnostic pop
+
 #include <utility>
 
 #include "../../../torchlive.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/utils/ArgumentParser.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/utils/ArgumentParser.h
@@ -9,7 +9,11 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 namespace torchlive {
 namespace utils {

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/utils/constants.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/utils/constants.h
@@ -7,7 +7,11 @@
 
 #pragma once
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 // Namespace alias for torch to avoid namespace conflicts with torchlive::torch
 namespace torch_ = torch;

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/utils/converter.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/utils/converter.cpp
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/script.h>
+#pragma clang diagnostic pop
+
 #include <cmath>
 
 #include "../TensorHostObject.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/utils/converter.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/utils/converter.h
@@ -9,7 +9,11 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 // Namespace alias for torch to avoid namespace conflicts with torchlive::torch
 namespace torch_ = torch;

--- a/react-native-pytorch-core/cxx/src/torchlive/torch/utils/helpers.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torch/utils/helpers.h
@@ -9,7 +9,11 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 #include "../TensorHostObject.h"
 

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/AbstractScriptModule.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/AbstractScriptModule.cpp
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/import.h>
+#pragma clang diagnostic pop
 
 #include "../torch/utils/helpers.h"
 #include "ATen/core/ivalue.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/AbstractScriptModule.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/AbstractScriptModule.h
@@ -9,8 +9,12 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 // Namespace alias for torch to avoid namespace conflicts with torchlive::torch
 namespace torch_ = torch;

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/CenterCropModule.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/CenterCropModule.cpp
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/import.h>
+#pragma clang diagnostic pop
 
 #include "../torch/utils/helpers.h"
 #include "ATen/core/ivalue.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/CenterCropModule.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/CenterCropModule.h
@@ -9,8 +9,12 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 #include "AbstractScriptModule.h"
 

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/GrayscaleModule.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/GrayscaleModule.cpp
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/import.h>
+#pragma clang diagnostic pop
 
 #include "../torch/utils/helpers.h"
 #include "ATen/core/ivalue.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/GrayscaleModule.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/GrayscaleModule.h
@@ -9,8 +9,12 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 #include "AbstractScriptModule.h"
 

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/NormalizeModule.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/NormalizeModule.cpp
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/import.h>
+#pragma clang diagnostic pop
 
 #include "../torch/utils/helpers.h"
 #include "ATen/core/ivalue.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/NormalizeModule.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/NormalizeModule.h
@@ -9,8 +9,12 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 #include "AbstractScriptModule.h"
 

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/ResizeModule.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/ResizeModule.cpp
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/import.h>
+#pragma clang diagnostic pop
 
 #include "../torch/utils/helpers.h"
 #include "ATen/core/ivalue.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/ResizeModule.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/ResizeModule.h
@@ -9,8 +9,12 @@
 
 #include <jsi/jsi.h>
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/script.h>
+#pragma clang diagnostic pop
 
 #include "AbstractScriptModule.h"
 

--- a/react-native-pytorch-core/cxx/src/torchlive/torchvision/VisionTransformHostObject.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/torchvision/VisionTransformHostObject.cpp
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <torch/csrc/jit/mobile/import.h>
+#pragma clang diagnostic pop
 
 #include "../torch/TensorHostObject.h"
 #include "../torch/utils/helpers.h"

--- a/react-native-pytorch-core/cxx/src/torchlive/vision/TransformsHostObject.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/vision/TransformsHostObject.cpp
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecated-declarations error to support Clang/C++17
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <ATen/Functions.h>
+#pragma clang diagnostic pop
+
 #include <string>
 
 #include "../torch/utils/helpers.h"

--- a/react-native-pytorch-core/ios/Media/Image/Image.h
+++ b/react-native-pytorch-core/ios/Media/Image/Image.h
@@ -35,8 +35,9 @@ public:
 
   void close() const override;
 
-private:
   UIImage *image_;
+
+private:
   std::string id_;
 };
 


### PR DESCRIPTION
Summary:
Introducing new toBlob API that works directly on the `ImageHostObject` rather than fetching the instance from the `JSContext`. This is a step towards deprecating the `NativeJSRef` in favor of a full JSI supported API.

`Playground.tsx`
```
import {useIsFocused} from 'react-navigation/native';
import * as React from 'react';
import {Button, StyleSheet, View} from 'react-native';
import {ImageUtil, media} from 'react-native-pytorch-core';

export default function Playground() {
  const isFocused = useIsFocused();

  const handleImage = async () => {
    const image1 = await ImageUtil.fromURL(
      'https://github.com/raedle/test-some/releases/download/v0.0.2.0/zidane.jpeg',
    );
    const width = image1.getWidth();
    const height = image1.getHeight();
    const blob1 = media.toBlob(image1);
    console.log('image1', image1);
    console.log('blob1', blob1);
    const image2 = media.imageFromBlob(blob1, width, height);
    const blob2 = media.toBlob(image2);
    console.log('image2', image2);
    console.log('blob2', blob2);

    image1.release();
  };

  if (!isFocused) {
    return null;
  }

  return (
    <View style={StyleSheet.absoluteFill}>
      <Button title="Convert to blob" onPress={handleImage} />
    </View>
  );
}
```
# Before Android Output

```
 LOG  image1 {"ID": "54c0bd8c-6304-4911-9fc0-baa23dfcccdd", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob1 {"arrayBuffer": [Function arrayBuffer], "size": 921600, "slice": [Function slice], "type": "image/x-playtorch-rgb"}
 LOG  image2 {"ID": "6b4e99f7-e096-462a-9b19-f1e04f2ee104", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob2 {"arrayBuffer": [Function arrayBuffer], "size": 921600, "slice": [Function slice], "type": "image/x-playtorch-rgb"}
```

# After Android Output

(temporarily changed the `blobType` to `Blob::kBlobTypeImageRGB + std::string("new_func")` to differentiate between the `toBlob(std::string& refId)` and `std::unique_ptr<torchlive::media::Blob> toBlob(std::shared_ptr<IImage> image)` function calls

```
 LOG  image1 {"ID": "c94513a8-e454-4e47-b151-79af2d557178", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob1 {"arrayBuffer": [Function arrayBuffer], "size": 921600, "slice": [Function slice], "type": "image/x-playtorch-rgb"}
 LOG  image2 {"ID": "9ea46769-a9eb-42e8-a2ff-e96ba7bdf8f0", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob2 {"arrayBuffer": [Function arrayBuffer], "size": 921600, "slice": [Function slice], "type": "image/x-playtorch-rgbnew_func"}
```

# Before iOS Output

```
 LOG  image1 {"ID": "94CDD792-612C-413B-BA54-DA2687C757E2", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob1 {"arrayBuffer": [Function arrayBuffer], "size": 921600, "slice": [Function slice], "type": "image/x-playtorch-rgb"}
 LOG  image2 {"ID": "E1CC23D8-9ED9-4DC5-B115-6DB0B284947C", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob2 {"arrayBuffer": [Function arrayBuffer], "size": 1228800, "slice": [Function slice], "type": "image/x-playtorch-rgb"}
```

# After iOS Output

(temporarily changed the `blobType` to `Blob::kBlobTypeImageRGB + std::string("new_func")` to differentiate between the `toBlob(std::string& refId)` and `std::unique_ptr<torchlive::media::Blob> toBlob(std::shared_ptr<IImage> image)` function calls

```
 LOG  image1 {"ID": "7738D4 (https://github.com/facebookresearch/playtorch/commit/71a14489b005facaf135070a5eae5bdfaa6bb0b4)E2-373B-4B07-8CAF-538F7BEA77D0", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob1 {"arrayBuffer": [Function arrayBuffer], "size": 921600, "slice": [Function slice], "type": "image/x-playtorch-rgb"}
 LOG  image2 {"ID": "1CF6BE0E-3C04-4937-90BD-41F3FEDC4AED", "getHeight": [Function getHeight], "getNaturalHeight": [Function getNaturalHeight], "getNaturalWidth": [Function getNaturalWidth], "getPixelDensity": [Function getPixelDensity], "getWidth": [Function getWidth], "release": [Function release], "scale": [Function scale]}
 LOG  blob2 {"arrayBuffer": [Function arrayBuffer], "size": 1228800, "slice": [Function slice], "type": "image/x-playtorch-rgbnew_func"}
```

Differential Revision: D40747567

