### PR TITLE
Patch failing issue with RN 0.64.3

### DIFF
--- a/react-native-template-pytorch-live/template/package.json
+++ b/react-native-template-pytorch-live/template/package.json
@@ -21,7 +21,7 @@
     "@react-navigation/native": "^5.9.3",
     "@react-navigation/stack": "^5.14.3",
     "react": "17.0.1",
-    "react-native": "^0.64.3",
+    "react-native": "^0.64.4",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-reanimated": "^2.0.0",
     "react-native-safe-area-context": "^3.2.0",

--- a/react-native-template-pytorch-live/template/yarn.lock
+++ b/react-native-template-pytorch-live/template/yarn.lock
@@ -6143,10 +6143,10 @@ react-native-vector-icons@^8.1.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native@^0.64.3:
-  version "0.64.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.3.tgz#40db6385963b4b17325f9cc86dd19132394b03fc"
-  integrity sha512-2OEU74U0Ek1/WeBzPbg6XDsCfjF/9fhrNX/5TFgEiBKd5mNc9LOZ/OlMmkb7iues/ZZ/oc51SbEfLRQdcW0fVw==
+react-native@^0.64.4:
+  version "0.64.4"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.4.tgz#f9870f6951378421881cc66f6b5a6451bef7254d"
+  integrity sha512-nxYt/NrTmGyW6+tOd+Hqp4O8uJ2LLZkN7ispMPDprAq7bwvLkF/GXmDQCZHAEyqXuhIztTtMX41KqFQ6UMCUJQ==
   dependencies:
     "@jest/create-cache-key-function" "^26.5.0"
     "@react-native-community/cli" "^5.0.1-alpha.1"


### PR DESCRIPTION
Summary:
This version is a patch release addressing the Android build issue that has been ongoing since Nov 4th 2022.

More details: https://github.com/facebook/react-native/issues/35210

Differential Revision: D41111537

