### PR TITLE
Fix issue with JNI Env not available for audio

### DIFF
--- a/react-native-pytorch-core/android/src/main/cpp/torchlive/media/audio/Audio.cpp
+++ b/react-native-pytorch-core/android/src/main/cpp/torchlive/media/audio/Audio.cpp
@@ -31,6 +31,13 @@ Audio::Audio(alias_ref<JIAudio> audio) : audio_(make_global(audio)) {
   id_ = wrapObjectMethod(mediaUtilsClass, audio)->toStdString();
 }
 
+Audio::~Audio() {
+  ThreadScope::WithClassLoader([&]() {
+    Environment::ensureCurrentThreadIsAttached();
+    this->audio_.release();
+  });
+}
+
 std::string Audio::getId() const {
   return id_;
 }

--- a/react-native-pytorch-core/android/src/main/cpp/torchlive/media/audio/Audio.h
+++ b/react-native-pytorch-core/android/src/main/cpp/torchlive/media/audio/Audio.h
@@ -19,7 +19,7 @@ namespace media {
 class Audio : public IAudio {
  public:
   Audio(facebook::jni::alias_ref<JIAudio> audio);
-  ~Audio() override = default;
+  ~Audio() override;
 
   std::string getId() const override;
 


### PR DESCRIPTION
Summary: The Hermes GC will eventually clean up orphan host objects. This is also the case for `AudioHostObject`, which itself has a reference to `Audio` that needs to be cleaned up, hence the call to the `Audio::~Audio` destructor. On Android, it will try to release the `global_ref<JAudio>` resource, which at the time, may not run in the JVM thread scope causing an app crash.

Differential Revision: D42060942

