### PR TITLE
Introduce new imageFromFile API function signature

### DIFF
--- a/react-native-pytorch-core/android/src/main/cpp/torchlive/media/NativeJSRefBridge.cpp
+++ b/react-native-pytorch-core/android/src/main/cpp/torchlive/media/NativeJSRefBridge.cpp
@@ -62,6 +62,16 @@ std::string imageToFile(
       ->toStdString();
 }
 
+std::shared_ptr<IImage> imageFromFile(std::string filepath) {
+  auto mediaUtilsClass = getMediaUtilsClass();
+  auto imageFromFileMethod =
+      mediaUtilsClass->getStaticMethod<local_ref<JIImage>(local_ref<JString>)>(
+          "imageFromFile");
+  local_ref<JIImage> image =
+      imageFromFileMethod(mediaUtilsClass, make_jstring(filepath));
+  return std::make_shared<Image>(make_global(image));
+}
+
 std::shared_ptr<IImage>
 imageFromBlob(const Blob& blob, double width, double height) {
   auto mediaUtilsClass = getMediaUtilsClass();

--- a/react-native-pytorch-core/android/src/main/cpp/torchlive/media/NativeJSRefBridge.cpp
+++ b/react-native-pytorch-core/android/src/main/cpp/torchlive/media/NativeJSRefBridge.cpp
@@ -40,6 +40,28 @@ alias_ref<JClass> getMediaUtilsClass() {
 
 namespace media {
 
+std::shared_ptr<IImage> resolveNativeJSRefToImage_DO_NOT_USE(
+    const std::string& refId) {
+  auto mediaUtilsClass = getMediaUtilsClass();
+  auto method =
+      mediaUtilsClass->getStaticMethod<local_ref<JIImage>(alias_ref<JString>)>(
+          "resolveNativeJSRefToImage_DO_NOT_USE");
+  local_ref<JIImage> image = method(mediaUtilsClass, make_jstring(refId));
+  return std::make_shared<Image>(make_global(image));
+}
+
+std::string imageToFile(
+    std::shared_ptr<IImage> image,
+    const std::string& filepath) {
+  std::shared_ptr<Image> derivedImage = std::dynamic_pointer_cast<Image>(image);
+  auto mediaUtilsClass = getMediaUtilsClass();
+  auto imageToFileMethod = mediaUtilsClass->getStaticMethod<local_ref<JString>(
+      alias_ref<JIImage>, alias_ref<JString>)>("imageToFile");
+  return imageToFileMethod(
+             mediaUtilsClass, derivedImage->image_, make_jstring(filepath))
+      ->toStdString();
+}
+
 std::shared_ptr<IImage>
 imageFromBlob(const Blob& blob, double width, double height) {
   auto mediaUtilsClass = getMediaUtilsClass();

--- a/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/javascript/JSContext.java
+++ b/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/javascript/JSContext.java
@@ -49,10 +49,14 @@ public class JSContext {
     return new NativeJSRef(object);
   }
 
-  public static <T> T unwrapObject(ReadableMap jsRef) {
-    String id = jsRef.getString(ID_KEY);
+  public static <T> T unwrapObject(String id) {
     NativeJSRef ref = JSContext.getRef(id);
     return (T) ref.getObject();
+  }
+
+  public static <T> T unwrapObject(ReadableMap jsRef) {
+    String id = jsRef.getString(ID_KEY);
+    return JSContext.unwrapObject(id);
   }
 
   public static final class NativeJSRef {

--- a/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/media/MediaUtils.java
+++ b/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/media/MediaUtils.java
@@ -8,6 +8,7 @@
 package org.pytorch.rn.core.media;
 
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import androidx.annotation.Keep;
 import com.facebook.proguard.annotations.DoNotStrip;
@@ -49,6 +50,13 @@ public class MediaUtils {
     final FileOutputStream outputStream = new FileOutputStream(filepath);
     bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
     return filepath;
+  }
+
+  @DoNotStrip
+  @Keep
+  public static IImage imageFromFile(final String filepath) {
+    Bitmap bitmap = BitmapFactory.decodeFile(filepath);
+    return new Image(bitmap);
   }
 
   @DoNotStrip

--- a/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/media/MediaUtils.java
+++ b/react-native-pytorch-core/android/src/main/java/org/pytorch/rn/core/media/MediaUtils.java
@@ -11,6 +11,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import androidx.annotation.Keep;
 import com.facebook.proguard.annotations.DoNotStrip;
+import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.pytorch.rn.core.audio.Audio;
@@ -24,6 +25,12 @@ public class MediaUtils {
 
   @DoNotStrip
   @Keep
+  public static IImage resolveNativeJSRefToImage_DO_NOT_USE(final String refId) {
+    return JSContext.unwrapObject(refId);
+  }
+
+  @DoNotStrip
+  @Keep
   public static String wrapObject(final Object obj) {
     final JSContext.NativeJSRef ref = JSContext.wrapObject(obj);
     return ref.getJSRef().getString("ID");
@@ -33,6 +40,15 @@ public class MediaUtils {
   @Keep
   public static void releaseObject(final String id) throws Exception {
     JSContext.release(id);
+  }
+
+  @DoNotStrip
+  @Keep
+  public static String imageToFile(final IImage image, final String filepath) throws Exception {
+    final Bitmap bitmap = image.getBitmap();
+    final FileOutputStream outputStream = new FileOutputStream(filepath);
+    bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
+    return filepath;
   }
 
   @DoNotStrip

--- a/react-native-pytorch-core/cxx/src/torchlive/media/MediaNamespace.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/MediaNamespace.cpp
@@ -69,6 +69,27 @@ jsi::Value imageToFileImpl(
   }
 }
 
+jsi::Value imageFromFileImpl(
+    jsi::Runtime& runtime,
+    const jsi::Value& thisValue,
+    const jsi::Value* arguments,
+    size_t count) {
+  auto args = utils::ArgumentParser(runtime, thisValue, arguments, count);
+  args.requireNumArguments(1);
+
+  auto filePath = args[0].asString(runtime).utf8(runtime);
+
+  std::shared_ptr<IImage> image;
+  try {
+    image = torchlive::media::imageFromFile(filePath);
+  } catch (const std::exception& e) {
+    throw jsi::JSError(
+        runtime, "error loading from file:\n" + std::string(e.what()));
+  }
+  return utils::helpers::createFromHostObject<ImageHostObject>(
+      runtime, std::move(image));
+}
+
 jsi::Value imageFromBlobImpl(
     jsi::Runtime& runtime,
     const jsi::Value& thisValue,
@@ -204,6 +225,7 @@ jsi::Object buildNamespace(jsi::Runtime& rt, RuntimeExecutor rte) {
   jsi::Object ns(rt);
   setPropertyHostFunction(rt, ns, "imageFromBlob", 3, imageFromBlobImpl);
   setPropertyHostFunction(rt, ns, "imageFromTensor", 1, imageFromTensorImpl);
+  setPropertyHostFunction(rt, ns, "imageFromFile", 1, imageFromFileImpl);
   setPropertyHostFunction(rt, ns, "toBlob", 1, toBlobImpl);
   setPropertyHostFunction(rt, ns, "imageToFile", 1, imageToFileImpl);
   return ns;

--- a/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridge.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridge.h
@@ -18,6 +18,18 @@ namespace torchlive {
 
 namespace media {
 
+/**
+ * The resolveNativeJSRefToImage_DO_NOT_USE function is needed to resolve
+ * NativeJSRef objects to IImage. This function will be removed without
+ * warning in future releases once NativeJSRef is fully deprecated.
+ */
+std::shared_ptr<IImage> resolveNativeJSRefToImage_DO_NOT_USE(
+    const std::string& refId);
+
+std::string imageToFile(
+    std::shared_ptr<IImage> image,
+    const std::string& filepath);
+
 std::shared_ptr<IImage>
 imageFromBlob(const Blob& blob, double width, double height);
 

--- a/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridge.h
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridge.h
@@ -30,6 +30,8 @@ std::string imageToFile(
     std::shared_ptr<IImage> image,
     const std::string& filepath);
 
+std::shared_ptr<IImage> imageFromFile(std::string filepath);
+
 std::shared_ptr<IImage>
 imageFromBlob(const Blob& blob, double width, double height);
 

--- a/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
@@ -31,6 +31,10 @@ imageFromBlob(const Blob& blob, double width, double height) {
   return nullptr;
 }
 
+std::shared_ptr<IImage> imageFromFile(std::string filepath) {
+  return nullptr;
+}
+
 std::unique_ptr<torchlive::media::Blob> toBlob(const std::string& refId) {
   size_t const size = 0;
   auto data = std::unique_ptr<uint8_t[]>(0);

--- a/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
+++ b/react-native-pytorch-core/cxx/src/torchlive/media/NativeJSRefBridgeCxx.cpp
@@ -15,6 +15,17 @@ namespace torchlive {
 
 namespace media {
 
+std::shared_ptr<IImage> resolveNativeJSRefToImage_DO_NOT_USE(
+    const std::string& refId) {
+  return nullptr;
+}
+
+std::string imageToFile(
+    std::shared_ptr<IImage> image,
+    const std::string& filepath) {
+  return filepath;
+}
+
 std::shared_ptr<IImage>
 imageFromBlob(const Blob& blob, double width, double height) {
   return nullptr;

--- a/react-native-pytorch-core/example/ios/Podfile
+++ b/react-native-pytorch-core/example/ios/Podfile
@@ -9,6 +9,7 @@ target 'PyTorchCoreExample' do
   use_react_native!(:path => config["reactNativePath"])
 
   pod 'react-native-pytorch-core', :path => '../..'
+  pod 'RNFS', :path => '../node_modules/react-native-fs'
 
   # Enables Flipper.
   #

--- a/react-native-pytorch-core/example/ios/Podfile.lock
+++ b/react-native-pytorch-core/example/ios/Podfile.lock
@@ -328,6 +328,8 @@ PODS:
     - React-cxxreact (= 0.64.3)
     - React-jsi (= 0.64.3)
     - React-perflogger (= 0.64.3)
+  - RNFS (2.20.0):
+    - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
   - RNScreens (3.4.0):
@@ -390,6 +392,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
@@ -470,6 +473,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNFS:
+    :path: "../node_modules/react-native-fs"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
@@ -521,12 +526,13 @@ SPEC CHECKSUMS:
   React-RCTVibration: c7f845861e79eae13dc1e8217a3cf47a3945b504
   React-runtimeexecutor: 493d9abb8b23c3f84e19ae221eeba92cadcb70dc
   ReactCommon: 8fea6422328e2fc093e25c9fac67adbcf0f04fb4
+  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNScreens: 21b73c94c9117e1110a79ee0ee80c93ccefed8ce
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
   Yoga: e6ecf3fa25af9d4c87e94ad7d5d292eedef49749
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 0f229e682fc15f9a783a3c06a0c1e8fbdab367bf
+PODFILE CHECKSUM: 9d5b161169bd67fdf2bbd7ac3494dfc53b70fed3
 
 COCOAPODS: 1.11.3

--- a/react-native-pytorch-core/example/package.json
+++ b/react-native-pytorch-core/example/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/stack": "^5.14.5",
     "react": "17.0.1",
     "react-native": "0.64.3",
+    "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.4.0",

--- a/react-native-pytorch-core/example/yarn.lock
+++ b/react-native-pytorch-core/example/yarn.lock
@@ -1858,6 +1858,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==
+
 base64-js@^1.1.2, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -5318,6 +5323,14 @@ react-native-codegen@^0.0.6:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
+react-native-fs@^2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.20.0.tgz#05a9362b473bfc0910772c0acbb73a78dbc810f6"
+  integrity sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==
+  dependencies:
+    base-64 "^0.1.0"
+    utf8 "^3.0.0"
+
 react-native-gesture-handler@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"
@@ -6403,6 +6416,11 @@ utf8-byte-length@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
   integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@~1.0.1:
   version "1.0.2"

--- a/react-native-pytorch-core/ios/Image/Image.swift
+++ b/react-native-pytorch-core/ios/Image/Image.swift
@@ -8,65 +8,67 @@
 import Foundation
 
 enum ImageError: Error {
-    case scale
+  case scale
 }
 
-public class Image: IImage {
+@objc(PTLImage)
+public class Image: NSObject, IImage {
 
-    private var image: IImage
-    private var closed: Bool = false
+  private var image: IImage
+  private var closed: Bool = false
 
-    init(image: CGImage) {
-        self.image = BitmapImage(image: image)
-    }
+  init(image: CGImage) {
+    self.image = BitmapImage(image: image)
+  }
 
-    init(image: CIImage) {
-        self.image = BitmapImage(image: image)
-    }
+  init(image: CIImage) {
+    self.image = BitmapImage(image: image)
+  }
 
-    init(imageData: ImageData, pixelDensity: CGFloat) {
-        self.image = ImageDataImage(imageData: imageData, pixelDensity: pixelDensity)
-    }
+  init(imageData: ImageData, pixelDensity: CGFloat) {
+    self.image = ImageDataImage(imageData: imageData, pixelDensity: pixelDensity)
+  }
 
-    public func getPixelDensity() -> CGFloat {
-        return self.image.getPixelDensity()
-    }
+  public func getPixelDensity() -> CGFloat {
+    return self.image.getPixelDensity()
+  }
 
-    public func getWidth() -> CGFloat {
-        return self.image.getWidth()
-    }
+  public func getWidth() -> CGFloat {
+    return self.image.getWidth()
+  }
 
-    public func getHeight() -> CGFloat {
-        return self.image.getHeight()
-    }
+  public func getHeight() -> CGFloat {
+    return self.image.getHeight()
+  }
 
-    public func getNaturalWidth() -> Int {
-        // Note: on Android, returns the width in device pixels so that it can be properly redrawn back to the canvas
-        // Since iOS always uses points (density independent), this will return the same as getWidth so that it can
-        // be properly redrawn back to the canvas
-        return self.image.getNaturalWidth()
-    }
+  public func getNaturalWidth() -> Int {
+    // Note: on Android, returns the width in device pixels so that it can be properly redrawn back to the canvas
+    // Since iOS always uses points (density independent), this will return the same as getWidth so that it can
+    // be properly redrawn back to the canvas
+    return self.image.getNaturalWidth()
+  }
 
-    public func getNaturalHeight() -> Int {
-        // Note: on Android, returns the height in device pixels so that it can be properly redrawn back to the canvas
-        // Since iOS always uses points (density independent), this will return the same as getHeight so that it can
-        // be properly redrawn back to the canvas
-        return self.image.getNaturalHeight()
-    }
+  public func getNaturalHeight() -> Int {
+    // Note: on Android, returns the height in device pixels so that it can be properly redrawn back to the canvas
+    // Since iOS always uses points (density independent), this will return the same as getHeight so that it can
+    // be properly redrawn back to the canvas
+    return self.image.getNaturalHeight()
+  }
 
-    public func scale(sx: CGFloat, sy: CGFloat) throws -> IImage {
-        return try self.image.scale(sx: sx, sy: sy)
-    }
+  public func scale(sx: CGFloat, sy: CGFloat) throws -> IImage {
+    return try self.image.scale(sx: sx, sy: sy)
+  }
 
-    public func getBitmap() -> CGImage? {
-        return self.image.getBitmap()
-    }
+  @objc
+  public func getBitmap() -> CGImage? {
+    return self.image.getBitmap()
+  }
 
-    public func close() throws {
-        self.closed = true
-    }
+  public func close() throws {
+    self.closed = true
+  }
 
-    public func isClosed() -> Bool {
-        return self.closed
-    }
+  public func isClosed() -> Bool {
+    return self.closed
+  }
 }

--- a/react-native-pytorch-core/ios/JavaScript/JSContext.swift
+++ b/react-native-pytorch-core/ios/JavaScript/JSContext.swift
@@ -10,74 +10,75 @@ import Foundation
 @objc(PTLJSContext)
 public class JSContext: NSObject {
 
-    enum JSContextError: Error {
-        case invalidParam
+  enum JSContextError: Error {
+    case invalidParam
+  }
+
+  public static let idKey = "ID"
+
+  public static var refs: [String: NativeJSRef] = [:]
+
+  public static func setRef(ref: NativeJSRef) -> String {
+    let refId = UUID().uuidString
+    JSContext.refs[refId] = ref
+    return refId
+  }
+
+  public static func getRef(refId: String) throws -> NativeJSRef {
+    guard let unwrappedNativeJSRef = JSContext.refs[refId] else { throw JSContextError.invalidParam }
+    return unwrappedNativeJSRef
+  }
+
+  public static func get(jsRef: [ String: String ]) throws -> NativeJSRef {
+    guard let refId = jsRef[idKey] else { throw JSContextError.invalidParam }
+    return try JSContext.getRef(refId: refId)
+  }
+
+  @objc
+  public static func release(jsRef: [ String: String ]) throws {
+    guard let refId = jsRef[idKey] else { throw JSContextError.invalidParam }
+    let removedJSRef = refs.removeValue(forKey: refId)
+    try removedJSRef?.release()
+  }
+
+  public static func wrapObject(object: Any) -> NativeJSRef {
+    return NativeJSRef(object: object)
+  }
+
+  @objc
+  public static func unwrapObject(jsRef: [ String: String ]) throws -> Any {
+    guard let refId = jsRef[idKey] else { throw JSContextError.invalidParam }
+    let ref = try JSContext.getRef(refId: refId)
+    return ref.getObject()
+  }
+
+  public class NativeJSRef {
+    // initialized mId and mJSRef to empty values to allow self to be used to set id in init()
+    private var mId: String? = ""
+    private var mObject: Any?
+    private var mJSRef: [String: String]? = [:]
+
+    init(object: Any) {
+      mObject = object
+      mId = JSContext.setRef(ref: self)
+      mJSRef?[JSContext.idKey] = mId
     }
 
-    public static let idKey = "ID"
-
-    public static var refs: [String: NativeJSRef] = [:]
-
-    public static func setRef(ref: NativeJSRef) -> String {
-        let refId = UUID().uuidString
-        JSContext.refs[refId] = ref
-        return refId
+    public func getJSRef() -> [String: String] {
+      return mJSRef ?? [:]
     }
 
-    public static func getRef(refId: String) throws -> NativeJSRef {
-        guard let unwrappedNativeJSRef = JSContext.refs[refId] else { throw JSContextError.invalidParam }
-        return unwrappedNativeJSRef
+    public func getObject() -> Any {
+      return mObject as Any
     }
 
-    public static func get(jsRef: [ String: String ]) throws -> NativeJSRef {
-        guard let refId = jsRef[idKey] else { throw JSContextError.invalidParam }
-        return try JSContext.getRef(refId: refId)
+    public func release() throws {
+      if let image = mObject as? Image {
+        try image.close()
+      }
+      mId = nil
+      mObject = nil
+      mJSRef = nil
     }
-
-    @objc
-    public static func release(jsRef: [ String: String ]) throws {
-        guard let refId = jsRef[idKey] else { throw JSContextError.invalidParam }
-        let removedJSRef = refs.removeValue(forKey: refId)
-        try removedJSRef?.release()
-    }
-
-    public static func wrapObject(object: Any) -> NativeJSRef {
-        return NativeJSRef(object: object)
-    }
-
-    public static func unwrapObject(jsRef: [ String: String ]) throws -> Any {
-        guard let refId = jsRef[idKey] else { throw JSContextError.invalidParam }
-        let ref = try JSContext.getRef(refId: refId)
-        return ref.getObject()
-    }
-
-    public class NativeJSRef {
-        // initialized mId and mJSRef to empty values to allow self to be used to set id in init()
-        private var mId: String? = ""
-        private var mObject: Any?
-        private var mJSRef: [String: String]? = [:]
-
-        init(object: Any) {
-            mObject = object
-            mId = JSContext.setRef(ref: self)
-            mJSRef?[JSContext.idKey] = mId
-        }
-
-        public func getJSRef() -> [String: String] {
-            return mJSRef ?? [:]
-        }
-
-        public func getObject() -> Any {
-            return mObject as Any
-        }
-
-        public func release() throws {
-            if let image = mObject as? Image {
-                try image.close()
-            }
-            mId = nil
-            mObject = nil
-            mJSRef = nil
-        }
-    }
+  }
 }

--- a/react-native-pytorch-core/ios/Media/NativeJSRefBridge.mm
+++ b/react-native-pytorch-core/ios/Media/NativeJSRefBridge.mm
@@ -44,6 +44,21 @@ std::shared_ptr<IImage> imageFromBlob(
   return std::make_shared<Image>(image);
 }
 
+std::shared_ptr<IImage> imageFromFile(std::string filePath) {
+  NSString* imageFilePath = [NSString stringWithUTF8String:filePath.c_str()];
+
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  BOOL isFileExist = [fileManager fileExistsAtPath:imageFilePath];
+  UIImage* image;
+  if (isFileExist) {
+    image = [[UIImage alloc] initWithContentsOfFile:imageFilePath];
+  } else {
+    // do something.
+    return nullptr;
+  }
+  return std::make_shared<Image>(image);
+}
+
 std::unique_ptr<torchlive::media::Blob> toBlob(const std::string& refId) {
   auto idRef = [NSString stringWithUTF8String:refId.c_str()];
   NSError *error = nil;

--- a/react-native-pytorch-core/ios/Media/NativeJSRefBridge.mm
+++ b/react-native-pytorch-core/ios/Media/NativeJSRefBridge.mm
@@ -20,6 +20,22 @@ namespace torchlive {
 
 namespace media {
 
+  std::shared_ptr<IImage> resolveNativeJSRefToImage_DO_NOT_USE(
+    const std::string& refId) {
+      NSError *error = nil;
+auto ptlImage = (PTLImage*) [PTLJSContext unwrapObjectWithJsRef:@{@"ID": [NSString stringWithUTF8String:refId.c_str()]} error:&error];
+      UIImage* image = [[UIImage alloc] initWithCGImage:[ptlImage getBitmap]];
+  return std::make_shared<Image>(image);
+    }
+
+std::string imageToFile(std::shared_ptr<IImage> image, const std::string& filepath) {
+   std::shared_ptr<Image> derivedImage = std::dynamic_pointer_cast<Image>(image);
+   UIImage* uiImage = derivedImage->image_;
+    NSData *imageData = UIImagePNGRepresentation(uiImage);
+    [imageData writeToFile:[NSString stringWithUTF8String:filepath.c_str()] atomically:YES];
+    return filepath;
+}
+
 std::shared_ptr<IImage> imageFromBlob(
     const Blob& blob,
     double width,

--- a/react-native-pytorch-core/src/torchlive/media.ts
+++ b/react-native-pytorch-core/src/torchlive/media.ts
@@ -115,6 +115,17 @@ export interface Media {
   imageToFile(image: Image, filepath: string): string;
 
   /**
+   * @experimental This function is experimental and can change.
+   *
+   * Loads an [[Image]] from a file. The function will throw an error if the
+   * image couldn't be loaded.
+   *
+   * @param filepath A local file path to an image.
+   * @returns An [[Image]] loaded from filepath.
+   */
+  imageFromFile(filepath: string): Image;
+
+  /**
    * Converts a [[Tensor]] or [[NativeJSRef]] into a [[Blob]]. The blob can be
    * used to create a [[Tensor]] object or convert into a [[NativeJSRef]] like
    * an image or audio.

--- a/react-native-pytorch-core/src/torchlive/media.ts
+++ b/react-native-pytorch-core/src/torchlive/media.ts
@@ -91,6 +91,30 @@ export interface Media {
   imageFromTensor(tensor: Tensor): Image;
 
   /**
+   * @experimental This function is experimental and can change.
+   *
+   * Saves an [[Image]] to a file. The second argument is the local filepath at
+   * which the image will be saved. The filepath can be created by using a
+   * third-party React Native package like `react-native-fs` (i.e., RNFS).
+   *
+   * ```typescript
+   * const image = await ImageUtil.fromURL('https://example.com/image.jpg');
+   * const filepath = media.imageToFile(
+   *   image,
+   *   RNFS.DownloadDirectoryPath + '/saved_image.png',
+   * );
+   * image.release();
+   * ```
+   *
+   * The function will throw an error if the [[Image]] couldn't be saved.
+   *
+   * @param image Image that should be saved to a file.
+   * @param filepath The filepath at which the image will be saved.
+   * @returns The filepath of the saved image.
+   */
+  imageToFile(image: Image, filepath: string): string;
+
+  /**
    * Converts a [[Tensor]] or [[NativeJSRef]] into a [[Blob]]. The blob can be
    * used to create a [[Tensor]] object or convert into a [[NativeJSRef]] like
    * an image or audio.


### PR DESCRIPTION
Summary:
Introduce new media API to get an image from a filepath.

Example with RNFS (react-native-fs) to get a valid filepath.

```typescript
import { media } from 'react-native-pytorch-core';
import * as RNFS from 'react-native-fs';

const image = media.imageFromFile(
  RNFS.DownloadDirectoryPath + '/saved_image.png',
);
// do something with image
```

Differential Revision: D40747568

